### PR TITLE
Add avatar customization submenu to main menu

### DIFF
--- a/corgi jeopardy/GameState.swift
+++ b/corgi jeopardy/GameState.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Centralized state management for the game. Stores player information, scoring,
+/// round progression, and lightweight board data. The model is intentionally
+/// simple for now but can be expanded as future tickets introduce additional
+/// gameplay systems.
+final class GameState {
+    /// Represents the possible rounds in the game.
+    enum RoundType: CaseIterable {
+        case jeopardy
+        case doubleJeopardy
+        case finalJeopardy
+
+        /// Provides the next round in the cycle or returns `nil` when the game is over.
+        func next() -> RoundType? {
+            switch self {
+            case .jeopardy:
+                return .doubleJeopardy
+            case .doubleJeopardy:
+                return .finalJeopardy
+            case .finalJeopardy:
+                return nil
+            }
+        }
+    }
+
+    /// Lightweight data representation for a clue on the board.
+    struct Clue {
+        let value: Int
+        let question: String
+        let answer: String
+        var isRevealed: Bool
+        var isDailyDouble: Bool
+        var isDailyDooDoo: Bool
+    }
+
+    static let shared = GameState()
+
+    /// Ordered list of players – index 0 is reserved for the human player.
+    let playerOrder: [String]
+    /// Convenience accessor for the primary human player identifier.
+    let humanPlayerId: String
+    /// The identifiers that represent AI opponents.
+    let aiPlayerIds: [String]
+
+    var playerScores: [String: Int]
+    var currentRound: RoundType
+    var currentTurn: String
+    var board: [[Clue]]
+
+    /// Mapping of player identifier to avatar image name.
+    var playerAvatars: [String: String]
+
+    private(set) var highScores: [Int]
+
+    /// All available avatar texture names in the project.
+    let availableAvatarNames: [String] = [
+        "corgi1.png",
+        "corgi2.png",
+        "corgi3.png",
+        "corgi4.png",
+        "corgi5.png"
+    ]
+
+    private let highScoresKey = "HighScores"
+
+    private init() {
+        // Default players – can be customized in future tickets.
+        let defaultPlayers = ["Player1", "AI1", "AI2"]
+        playerOrder = defaultPlayers
+        humanPlayerId = defaultPlayers.first ?? "Player1"
+        aiPlayerIds = Array(defaultPlayers.dropFirst())
+
+        playerScores = Dictionary(uniqueKeysWithValues: defaultPlayers.map { ($0, 0) })
+        currentRound = .jeopardy
+        currentTurn = humanPlayerId
+        board = []
+        playerAvatars = [:]
+
+        highScores = UserDefaults.standard.array(forKey: highScoresKey) as? [Int] ?? []
+
+        assignDefaultAvatars()
+    }
+
+    /// Resets the entire game state back to its initial configuration.
+    func reset() {
+        for playerId in playerOrder {
+            playerScores[playerId] = 0
+        }
+        currentRound = .jeopardy
+        currentTurn = humanPlayerId
+        board.removeAll()
+        assignDefaultAvatars()
+    }
+
+    /// Updates the score for a specific player by the provided delta.
+    func updateScore(player: String, amount: Int) {
+        let existing = playerScores[player] ?? 0
+        playerScores[player] = existing + amount
+    }
+
+    /// Progresses the game to the next round, if available.
+    func nextRound() {
+        if let next = currentRound.next() {
+            currentRound = next
+        }
+    }
+
+    /// Records a new high score entry.
+    func recordHighScore(_ score: Int) {
+        highScores.append(score)
+        highScores.sort(by: >)
+        highScores = Array(highScores.prefix(10))
+        UserDefaults.standard.set(highScores, forKey: highScoresKey)
+    }
+
+    /// Ensures AI opponents have avatar assignments, generating random ones if necessary.
+    func ensureAIAvatarsAssigned() {
+        let humanAvatar = playerAvatars[humanPlayerId]
+        let excluded = humanAvatar.map { [$0] } ?? []
+        let requiresAssignment = aiPlayerIds.contains { playerAvatars[$0] == nil }
+        if requiresAssignment {
+            assignRandomAvatarsToAI(excluding: excluded)
+        }
+    }
+
+    /// Updates the stored avatar for a specific player.
+    func setAvatar(_ imageName: String, for player: String) {
+        playerAvatars[player] = imageName
+    }
+
+    /// Returns the avatar name for a player, falling back to a default if needed.
+    func avatarName(for player: String) -> String {
+        if let stored = playerAvatars[player] {
+            return stored
+        }
+        // Provide a deterministic fallback to keep UI stable.
+        if player == humanPlayerId {
+            return availableAvatarNames.first ?? "corgi1.png"
+        }
+        // Assign random avatar on the fly for AI opponents if missing.
+        assignRandomAvatarsToAI(excluding: Array(Set(playerAvatars.values)))
+        return playerAvatars[player] ?? availableAvatarNames.first ?? "corgi1.png"
+    }
+
+    /// Assigns random avatars to AI opponents, optionally avoiding a collection of names.
+    func assignRandomAvatarsToAI(excluding excludedNames: [String]) {
+        var pool = availableAvatarNames.filter { !excludedNames.contains($0) }
+        if pool.isEmpty {
+            pool = availableAvatarNames
+        }
+
+        for aiId in aiPlayerIds {
+            if pool.isEmpty {
+                pool = availableAvatarNames
+            }
+            let avatar = pool.randomElement() ?? availableAvatarNames.first ?? "corgi1.png"
+            playerAvatars[aiId] = avatar
+            if let index = pool.firstIndex(of: avatar) {
+                pool.remove(at: index)
+            }
+        }
+    }
+
+    /// Assigns a default avatar to the human player and random avatars to AI opponents.
+    private func assignDefaultAvatars() {
+        let defaultAvatar = availableAvatarNames.first ?? "corgi1.png"
+        playerAvatars[humanPlayerId] = defaultAvatar
+        assignRandomAvatarsToAI(excluding: [defaultAvatar])
+    }
+}

--- a/corgi jeopardy/GameViewController.swift
+++ b/corgi jeopardy/GameViewController.swift
@@ -1,44 +1,20 @@
-//
-//  GameViewController.swift
-//  corgi jeopardy
-//
-//  Created by John Clem on 10/2/25.
-//
-
 import UIKit
 import SpriteKit
-import GameplayKit
 
 class GameViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // Load 'GameScene.sks' as a GKScene. This provides gameplay related content
-        // including entities and graphs.
-        if let scene = GKScene(fileNamed: "GameScene") {
-            
-            // Get the SKScene from the loaded GKScene
-            if let sceneNode = scene.rootNode as! GameScene? {
-                
-                // Copy gameplay related content over to the scene
-                sceneNode.entities = scene.entities
-                sceneNode.graphs = scene.graphs
-                
-                // Set the scale mode to scale to fit the window
-                sceneNode.scaleMode = .aspectFill
-                
-                // Present the scene
-                if let view = self.view as! SKView? {
-                    view.presentScene(sceneNode)
-                    
-                    view.ignoresSiblingOrder = true
-                    
-                    view.showsFPS = true
-                    view.showsNodeCount = true
-                }
-            }
-        }
+
+        guard let view = self.view as? SKView else { return }
+
+        let scene = MainMenuScene(size: view.bounds.size)
+        scene.scaleMode = .aspectFill
+        view.presentScene(scene)
+
+        view.ignoresSiblingOrder = true
+        view.showsFPS = false
+        view.showsNodeCount = false
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/corgi jeopardy/MainMenuScene.swift
+++ b/corgi jeopardy/MainMenuScene.swift
@@ -1,0 +1,259 @@
+import SpriteKit
+
+/// Landing screen for the game that lets players start a session or customize
+/// their corgi avatar.
+final class MainMenuScene: SKScene {
+    private enum MenuState {
+        case main
+        case customization
+    }
+
+    private let gameState = GameState.shared
+
+    private let mainContainer = SKNode()
+    private let submenuContainer = SKNode()
+
+    private let titleLabel: SKLabelNode = {
+        let label = SKLabelNode(fontNamed: "AvenirNext-Bold")
+        label.text = "Corgi Jeopardy"
+        label.fontSize = 56
+        label.fontColor = .white
+        label.verticalAlignmentMode = .center
+        return label
+    }()
+
+    private let playButton: SKLabelNode = {
+        let label = SKLabelNode(fontNamed: "AvenirNext-Bold")
+        label.text = "Play Game"
+        label.fontSize = 36
+        label.fontColor = .white
+        label.name = "playButton"
+        label.verticalAlignmentMode = .center
+        return label
+    }()
+
+    private let customizeButton: SKLabelNode = {
+        let label = SKLabelNode(fontNamed: "AvenirNext-Regular")
+        label.text = "Customize Corgi"
+        label.fontSize = 28
+        label.fontColor = .white
+        label.name = "customizeButton"
+        label.verticalAlignmentMode = .center
+        return label
+    }()
+
+    private let customizeTitle: SKLabelNode = {
+        let label = SKLabelNode(fontNamed: "AvenirNext-Bold")
+        label.text = "Choose Your Corgi"
+        label.fontSize = 42
+        label.fontColor = .white
+        label.verticalAlignmentMode = .center
+        return label
+    }()
+
+    private let instructionsLabel: SKLabelNode = {
+        let label = SKLabelNode(fontNamed: "AvenirNext-Regular")
+        label.text = "Tap a corgi to select it, then confirm."
+        label.fontSize = 24
+        label.fontColor = .white
+        label.verticalAlignmentMode = .center
+        return label
+    }()
+
+    private let confirmButton: SKLabelNode = {
+        let label = SKLabelNode(fontNamed: "AvenirNext-Bold")
+        label.text = "Confirm"
+        label.fontSize = 32
+        label.fontColor = .white
+        label.name = "confirmButton"
+        label.verticalAlignmentMode = .center
+        return label
+    }()
+
+    private let backButton: SKLabelNode = {
+        let label = SKLabelNode(fontNamed: "AvenirNext-Regular")
+        label.text = "Back"
+        label.fontSize = 26
+        label.fontColor = .white
+        label.name = "backButton"
+        label.verticalAlignmentMode = .center
+        return label
+    }()
+
+    private let selectionIndicator: SKShapeNode = {
+        let indicator = SKShapeNode(rectOf: CGSize(width: 150, height: 150), cornerRadius: 20)
+        indicator.strokeColor = SKColor.yellow
+        indicator.lineWidth = 6
+        indicator.zPosition = 10
+        indicator.isHidden = true
+        return indicator
+    }()
+
+    private var menuState: MenuState = .main
+    private var avatarNodes: [SKSpriteNode] = []
+    private var selectedAvatarName: String? {
+        didSet { updateSelectionIndicator() }
+    }
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(red: 16 / 255, green: 32 / 255, blue: 64 / 255, alpha: 1)
+
+        addChild(mainContainer)
+        addChild(submenuContainer)
+        submenuContainer.isHidden = true
+
+        setupMainMenu()
+        layoutMainMenu()
+    }
+
+    // MARK: - Setup
+
+    private func setupMainMenu() {
+        mainContainer.removeAllChildren()
+        mainContainer.addChild(titleLabel)
+        mainContainer.addChild(playButton)
+        mainContainer.addChild(customizeButton)
+    }
+
+    private func layoutMainMenu() {
+        titleLabel.position = CGPoint(x: size.width / 2, y: size.height * 0.65)
+        playButton.position = CGPoint(x: size.width / 2, y: size.height * 0.45)
+        customizeButton.position = CGPoint(x: size.width / 2, y: size.height * 0.35)
+    }
+
+    private func setupCustomizationMenu() {
+        submenuContainer.removeAllChildren()
+        submenuContainer.addChild(customizeTitle)
+        submenuContainer.addChild(instructionsLabel)
+        submenuContainer.addChild(confirmButton)
+        submenuContainer.addChild(backButton)
+        submenuContainer.addChild(selectionIndicator)
+
+        let avatarNames = gameState.availableAvatarNames
+        avatarNodes = avatarNames.enumerated().map { index, name in
+            let node = makeAvatarNode(imageName: name, colorIndex: index)
+            node.name = "avatar_\(name)"
+            return node
+        }
+
+        let avatarContainer = SKNode()
+        avatarContainer.name = "avatarContainer"
+        let spacing = (avatarNodes.first?.size.width ?? 140) + 30
+        let totalWidth = CGFloat(max(avatarNodes.count - 1, 0)) * spacing
+        let startingX = -totalWidth / 2
+        for (index, node) in avatarNodes.enumerated() {
+            let positionX = startingX + CGFloat(index) * spacing
+            node.position = CGPoint(x: positionX, y: 0)
+            avatarContainer.addChild(node)
+        }
+        avatarContainer.position = CGPoint(x: size.width / 2, y: size.height * 0.45)
+        submenuContainer.addChild(avatarContainer)
+
+        customizeTitle.position = CGPoint(x: size.width / 2, y: size.height * 0.72)
+        instructionsLabel.position = CGPoint(x: size.width / 2, y: size.height * 0.62)
+        confirmButton.position = CGPoint(x: size.width / 2, y: size.height * 0.25)
+        backButton.position = CGPoint(x: size.width / 2, y: size.height * 0.18)
+
+        selectedAvatarName = gameState.playerAvatars[gameState.humanPlayerId]
+        updateSelectionIndicator()
+    }
+
+    private func makeAvatarNode(imageName: String, colorIndex: Int) -> SKSpriteNode {
+        let avatarSize = CGSize(width: 140, height: 140)
+        let texture = SKTexture(imageNamed: imageName)
+        if texture.size() == .zero {
+            let placeholder = SKSpriteNode(color: placeholderColor(for: colorIndex), size: avatarSize)
+            placeholder.name = "avatar_\(imageName)"
+            let label = SKLabelNode(fontNamed: "AvenirNext-Bold")
+            label.text = imageName.replacingOccurrences(of: ".png", with: "").capitalized
+            label.fontSize = 20
+            label.fontColor = .white
+            label.verticalAlignmentMode = .center
+            label.horizontalAlignmentMode = .center
+            placeholder.addChild(label)
+            return placeholder
+        } else {
+            let sprite = SKSpriteNode(texture: texture, color: .clear, size: avatarSize)
+            sprite.name = "avatar_\(imageName)"
+            return sprite
+        }
+    }
+
+    private func placeholderColor(for index: Int) -> SKColor {
+        let palette: [SKColor] = [
+            SKColor(red: 244 / 255, green: 162 / 255, blue: 97 / 255, alpha: 1),
+            SKColor(red: 233 / 255, green: 196 / 255, blue: 106 / 255, alpha: 1),
+            SKColor(red: 42 / 255, green: 157 / 255, blue: 143 / 255, alpha: 1),
+            SKColor(red: 38 / 255, green: 70 / 255, blue: 83 / 255, alpha: 1),
+            SKColor(red: 231 / 255, green: 111 / 255, blue: 81 / 255, alpha: 1)
+        ]
+        return palette[index % palette.count]
+    }
+
+    private func updateSelectionIndicator() {
+        guard let selectedName = selectedAvatarName,
+              let targetNode = avatarNodes.first(where: { $0.name == "avatar_\(selectedName)" }) else {
+            selectionIndicator.isHidden = true
+            return
+        }
+
+        selectionIndicator.isHidden = false
+        selectionIndicator.position = submenuContainer.convert(targetNode.position, from: targetNode.parent ?? submenuContainer)
+    }
+
+    // MARK: - Scene transitions
+
+    private func showMainMenu() {
+        menuState = .main
+        mainContainer.isHidden = false
+        submenuContainer.isHidden = true
+    }
+
+    private func showCustomizationMenu() {
+        menuState = .customization
+        mainContainer.isHidden = true
+        submenuContainer.isHidden = false
+        setupCustomizationMenu()
+    }
+
+    private func confirmSelection() {
+        guard let avatarName = selectedAvatarName else { return }
+        gameState.setAvatar(avatarName, for: gameState.humanPlayerId)
+        gameState.assignRandomAvatarsToAI(excluding: [avatarName])
+        showMainMenu()
+    }
+
+    private func startGame() {
+        gameState.ensureAIAvatarsAssigned()
+        let scene = GameScene(size: size)
+        scene.scaleMode = scaleMode
+        let transition = SKTransition.fade(withDuration: 0.5)
+        view?.presentScene(scene, transition: transition)
+    }
+
+    // MARK: - Touch handling
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        let location = touch.location(in: self)
+        let nodesAtPoint = nodes(at: location)
+
+        switch menuState {
+        case .main:
+            if nodesAtPoint.contains(where: { $0.name == playButton.name }) {
+                startGame()
+            } else if nodesAtPoint.contains(where: { $0.name == customizeButton.name }) {
+                showCustomizationMenu()
+            }
+        case .customization:
+            if let avatarNode = nodesAtPoint.first(where: { $0.name?.hasPrefix("avatar_") == true }),
+               let name = avatarNode.name?.replacingOccurrences(of: "avatar_", with: "") {
+                selectedAvatarName = name
+            } else if nodesAtPoint.contains(where: { $0.name == confirmButton.name }) {
+                confirmSelection()
+            } else if nodesAtPoint.contains(where: { $0.name == backButton.name }) {
+                showMainMenu()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a central `GameState` model that tracks players, avatars, and helper behaviors
- build a `MainMenuScene` with a corgi avatar customization submenu for the human player while randomizing AI avatars
- refresh the gameplay scene and view controller to load the menu first and display chosen avatars on the board

## Testing
- not run (iOS SpriteKit project)

------
https://chatgpt.com/codex/tasks/task_e_68e01adecbec832cbb886dcab3c1f773