### PR TITLE
Implement GameBoardScene with corgi host animation

### DIFF
--- a/corgi jeopardy/ClueScene.swift
+++ b/corgi jeopardy/ClueScene.swift
@@ -1,0 +1,57 @@
+//
+//  ClueScene.swift
+//  corgi jeopardy
+//
+//  Minimal placeholder scene that displays the selected clue.
+//
+
+import SpriteKit
+
+final class ClueScene: SKScene {
+    private let clue: Clue
+
+    init(size: CGSize, clue: Clue) {
+        self.clue = clue
+        super.init(size: size)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(red: 20 / 255, green: 20 / 255, blue: 40 / 255, alpha: 1)
+
+        let titleLabel = SKLabelNode(fontNamed: "AvenirNext-Bold")
+        titleLabel.text = "$\(clue.value)"
+        titleLabel.fontSize = 48
+        titleLabel.fontColor = SKColor(red: 0.96, green: 0.78, blue: 0.22, alpha: 1)
+        titleLabel.position = CGPoint(x: size.width / 2, y: size.height * 0.7)
+        addChild(titleLabel)
+
+        let questionLabel = SKLabelNode(fontNamed: "AvenirNext-Regular")
+        questionLabel.text = clue.question
+        questionLabel.fontSize = 32
+        questionLabel.fontColor = .white
+        questionLabel.position = CGPoint(x: size.width / 2, y: size.height / 2)
+        questionLabel.horizontalAlignmentMode = .center
+        questionLabel.verticalAlignmentMode = .center
+        questionLabel.numberOfLines = 0
+        questionLabel.preferredMaxLayoutWidth = size.width * 0.8
+        addChild(questionLabel)
+
+        let instructionLabel = SKLabelNode(fontNamed: "AvenirNext-Medium")
+        instructionLabel.text = "Tap to return"
+        instructionLabel.fontSize = 20
+        instructionLabel.fontColor = SKColor(white: 0.8, alpha: 1)
+        instructionLabel.position = CGPoint(x: size.width / 2, y: size.height * 0.2)
+        addChild(instructionLabel)
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        let boardScene = GameBoardScene(size: size)
+        boardScene.scaleMode = scaleMode
+        let transition = SKTransition.fade(withDuration: 0.3)
+        view?.presentScene(boardScene, transition: transition)
+    }
+}

--- a/corgi jeopardy/GameBoardScene.swift
+++ b/corgi jeopardy/GameBoardScene.swift
@@ -1,0 +1,183 @@
+//
+//  GameBoardScene.swift
+//  corgi jeopardy
+//
+//  Displays the Jeopardy style board with categories, clues and a corgi host.
+//
+
+import SpriteKit
+
+final class GameBoardScene: SKScene {
+    private let gameState = GameState.shared
+    private var tileNodes: [[SKSpriteNode]] = []
+    private var hostNode: SKSpriteNode?
+
+    private let numberOfColumns = 6
+    private let numberOfRows = 5
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(red: 9 / 255, green: 26 / 255, blue: 64 / 255, alpha: 1)
+        hostNode = nil
+        removeAllChildren()
+        layoutCategories()
+        layoutClueTiles()
+        addHostIfNeeded()
+    }
+
+    private func layoutCategories() {
+        let topMargin: CGFloat = size.height * 0.1
+        let sideMargin: CGFloat = size.width * 0.05
+        let availableWidth = size.width - (sideMargin * 2)
+        let columnWidth = availableWidth / CGFloat(numberOfColumns)
+        let labelHeight = size.height * 0.1
+        let baseY = size.height - topMargin - (labelHeight / 2)
+
+        for (column, category) in gameState.board.enumerated() {
+            let label = SKLabelNode(fontNamed: "AvenirNext-Bold")
+            label.text = category.title.uppercased()
+            label.fontColor = .white
+            label.fontSize = min(22, columnWidth * 0.25)
+            label.horizontalAlignmentMode = .center
+            label.verticalAlignmentMode = .center
+            label.numberOfLines = 2
+            label.preferredMaxLayoutWidth = columnWidth - 8
+
+            let positionX = sideMargin + (columnWidth * (CGFloat(column) + 0.5))
+            label.position = CGPoint(x: positionX, y: baseY)
+
+            let background = SKSpriteNode(color: SKColor(red: 0.0, green: 0.2, blue: 0.7, alpha: 1), size: CGSize(width: columnWidth - 6, height: labelHeight))
+            background.position = label.position
+            background.zPosition = 0
+            addChild(background)
+
+            label.zPosition = 1
+            addChild(label)
+        }
+    }
+
+    private func layoutClueTiles() {
+        tileNodes = Array(repeating: [], count: numberOfColumns)
+
+        let sideMargin: CGFloat = size.width * 0.05
+        let topOffset: CGFloat = size.height * 0.3
+        let bottomMargin: CGFloat = size.height * 0.1
+        let availableHeight = size.height - topOffset - bottomMargin
+        let availableWidth = size.width - (sideMargin * 2)
+        let columnWidth = availableWidth / CGFloat(numberOfColumns)
+        let rowHeight = availableHeight / CGFloat(numberOfRows)
+
+        for column in 0..<numberOfColumns {
+            var columnTiles: [SKSpriteNode] = []
+            for row in 0..<numberOfRows {
+                let tileSize = CGSize(width: columnWidth - 8, height: rowHeight - 8)
+                let tile = SKSpriteNode(color: SKColor(red: 0.0, green: 0.1, blue: 0.45, alpha: 1), size: tileSize)
+                tile.name = nodeNameForTile(column: column, row: row)
+                tile.zPosition = 0
+
+                let positionX = sideMargin + (columnWidth * (CGFloat(column) + 0.5))
+                let positionY = size.height - topOffset - (rowHeight * (CGFloat(row) + 0.5))
+                tile.position = CGPoint(x: positionX, y: positionY)
+
+                let valueLabel = SKLabelNode(fontNamed: "AvenirNext-Heavy")
+                valueLabel.fontSize = min(32, rowHeight * 0.4)
+                valueLabel.fontColor = SKColor(red: 0.96, green: 0.78, blue: 0.22, alpha: 1)
+                valueLabel.verticalAlignmentMode = .center
+                valueLabel.horizontalAlignmentMode = .center
+                valueLabel.zPosition = 1
+                valueLabel.name = "label-\(tile.name ?? "")"
+
+                if let clue = gameState.clue(atColumn: column, row: row) {
+                    valueLabel.text = "$\(clue.value)"
+                    applyAppearance(for: clue, tile: tile, label: valueLabel)
+                } else {
+                    valueLabel.text = "--"
+                }
+
+                tile.addChild(valueLabel)
+                addChild(tile)
+
+                columnTiles.append(tile)
+            }
+            tileNodes[column] = columnTiles
+        }
+    }
+
+    private func applyAppearance(for clue: Clue, tile: SKSpriteNode, label: SKLabelNode) {
+        if clue.isRevealed {
+            tile.color = SKColor(white: 0.35, alpha: 1)
+            label.fontColor = SKColor(white: 0.8, alpha: 1)
+        } else {
+            tile.color = SKColor(red: 0.0, green: 0.1, blue: 0.45, alpha: 1)
+            label.fontColor = SKColor(red: 0.96, green: 0.78, blue: 0.22, alpha: 1)
+        }
+    }
+
+    private func addHostIfNeeded() {
+        guard hostNode == nil else { return }
+
+        let texture = SKTexture(imageNamed: "corgiHost")
+        let host = SKSpriteNode(texture: texture)
+        host.size = CGSize(width: size.width * 0.2, height: size.width * 0.2)
+        host.anchorPoint = CGPoint(x: 0.5, y: 0)
+        host.position = CGPoint(x: -host.size.width, y: size.height * 0.05)
+        host.zPosition = 5
+        addChild(host)
+        hostNode = host
+
+        let enter = SKAction.moveTo(x: size.width * 0.15, duration: 0.6)
+        enter.timingMode = .easeOut
+        let wag = SKAction.sequence([
+            SKAction.scaleX(to: 1.05, duration: 0.2),
+            SKAction.scaleX(to: 0.95, duration: 0.2)
+        ])
+        let wagRepeat = SKAction.repeat(wag, count: 3)
+        host.run(SKAction.sequence([enter, wagRepeat]))
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        let location = touch.location(in: self)
+        let nodes = nodes(at: location)
+
+        guard let tileNode = nodes.compactMap({ node -> SKSpriteNode? in
+            if let sprite = node as? SKSpriteNode, sprite.name?.hasPrefix("tile-") == true {
+                return sprite
+            }
+            if let label = node as? SKLabelNode, let parent = label.parent as? SKSpriteNode, parent.name?.hasPrefix("tile-") == true {
+                return parent
+            }
+            return nil
+        }).first else { return }
+
+        handleSelection(for: tileNode)
+    }
+
+    private func handleSelection(for tileNode: SKSpriteNode) {
+        guard let name = tileNode.name else { return }
+        let components = name.split(separator: "-")
+        guard components.count == 3,
+              let column = Int(components[1]),
+              let row = Int(components[2]),
+              let clue = gameState.clue(atColumn: column, row: row),
+              !clue.isRevealed else { return }
+
+        gameState.markClueRevealed(atColumn: column, row: row)
+        if let label = tileNode.children.compactMap({ $0 as? SKLabelNode }).first,
+           let updatedClue = gameState.clue(atColumn: column, row: row) {
+            applyAppearance(for: updatedClue, tile: tileNode, label: label)
+        }
+
+        transitionToClueScene(with: clue)
+    }
+
+    private func transitionToClueScene(with clue: Clue) {
+        let nextScene = ClueScene(size: size, clue: clue)
+        nextScene.scaleMode = scaleMode
+        let transition = SKTransition.fade(withDuration: 0.5)
+        view?.presentScene(nextScene, transition: transition)
+    }
+
+    private func nodeNameForTile(column: Int, row: Int) -> String {
+        return "tile-\(column)-\(row)"
+    }
+}

--- a/corgi jeopardy/GameState.swift
+++ b/corgi jeopardy/GameState.swift
@@ -1,0 +1,86 @@
+//
+//  GameState.swift
+//  corgi jeopardy
+//
+//  Created as part of Ticket 2.2 to back the game board scene.
+//
+
+import Foundation
+
+struct Clue: Identifiable {
+    let id = UUID()
+    let value: Int
+    let question: String
+    let answer: String
+    var isRevealed: Bool
+    var isDailyDouble: Bool
+    var isDailyDooDoo: Bool
+}
+
+struct Category {
+    let title: String
+    var clues: [Clue]
+}
+
+final class GameState {
+    static let shared = GameState()
+
+    enum RoundType {
+        case jeopardy
+        case doubleJeopardy
+        case finalJeopardy
+    }
+
+    private(set) var playerScores: [String: Int] = [:]
+    private(set) var currentRound: RoundType = .jeopardy
+    private(set) var currentTurn: String = "Player1"
+    private(set) var board: [Category] = []
+
+    private init() {
+        resetBoard()
+    }
+
+    func resetBoard() {
+        board = GameState.generateDefaultBoard(for: currentRound)
+    }
+
+    func clue(atColumn column: Int, row: Int) -> Clue? {
+        guard board.indices.contains(column), board[column].clues.indices.contains(row) else {
+            return nil
+        }
+        return board[column].clues[row]
+    }
+
+    func markClueRevealed(atColumn column: Int, row: Int) {
+        guard board.indices.contains(column), board[column].clues.indices.contains(row) else { return }
+        board[column].clues[row].isRevealed = true
+    }
+
+    private static func generateDefaultBoard(for round: RoundType) -> [Category] {
+        let baseValues = [200, 400, 600, 800, 1000]
+        let categories = [
+            "Corgi Breeds",
+            "Dog Tricks",
+            "Famous Pups",
+            "Paw-some Places",
+            "Treats & Eats",
+            "Tail Tales"
+        ]
+
+        return categories.map { title in
+            let clues = baseValues.enumerated().map { rowIndex, value -> Clue in
+                let multiplier = (round == .doubleJeopardy) ? 2 : 1
+                let adjustedValue = value * multiplier
+                return Clue(
+                    value: adjustedValue,
+                    question: "Placeholder question #\(rowIndex + 1) for \(title).",
+                    answer: "Placeholder answer",
+                    isRevealed: false,
+                    isDailyDouble: false,
+                    isDailyDooDoo: false
+                )
+            }
+            return Category(title: title, clues: clues)
+        }
+    }
+}

--- a/corgi jeopardy/GameViewController.swift
+++ b/corgi jeopardy/GameViewController.swift
@@ -14,31 +14,15 @@ class GameViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // Load 'GameScene.sks' as a GKScene. This provides gameplay related content
-        // including entities and graphs.
-        if let scene = GKScene(fileNamed: "GameScene") {
-            
-            // Get the SKScene from the loaded GKScene
-            if let sceneNode = scene.rootNode as! GameScene? {
-                
-                // Copy gameplay related content over to the scene
-                sceneNode.entities = scene.entities
-                sceneNode.graphs = scene.graphs
-                
-                // Set the scale mode to scale to fit the window
-                sceneNode.scaleMode = .aspectFill
-                
-                // Present the scene
-                if let view = self.view as! SKView? {
-                    view.presentScene(sceneNode)
-                    
-                    view.ignoresSiblingOrder = true
-                    
-                    view.showsFPS = true
-                    view.showsNodeCount = true
-                }
-            }
-        }
+        guard let skView = view as? SKView else { return }
+
+        let boardScene = GameBoardScene(size: skView.bounds.size)
+        boardScene.scaleMode = .resizeFill
+        skView.presentScene(boardScene)
+
+        skView.ignoresSiblingOrder = true
+        skView.showsFPS = true
+        skView.showsNodeCount = true
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {


### PR DESCRIPTION
## Summary
- add a GameState model to manage categories and clues for the board
- build a GameBoardScene that lays out category headers, clue tiles, and a corgi host animation
- create a minimal ClueScene and update GameViewController to launch the new board scene

## Testing
- not run (SpriteKit project requires Xcode/iOS simulator)


------
https://chatgpt.com/codex/tasks/task_e_68e01af38708832cbc2896bf500f83cb