### PR TITLE
Add round transition flow and board regeneration

### DIFF
--- a/corgi jeopardy/GameViewController.swift
+++ b/corgi jeopardy/GameViewController.swift
@@ -7,38 +7,22 @@
 
 import UIKit
 import SpriteKit
-import GameplayKit
 
 class GameViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // Load 'GameScene.sks' as a GKScene. This provides gameplay related content
-        // including entities and graphs.
-        if let scene = GKScene(fileNamed: "GameScene") {
-            
-            // Get the SKScene from the loaded GKScene
-            if let sceneNode = scene.rootNode as! GameScene? {
-                
-                // Copy gameplay related content over to the scene
-                sceneNode.entities = scene.entities
-                sceneNode.graphs = scene.graphs
-                
-                // Set the scale mode to scale to fit the window
-                sceneNode.scaleMode = .aspectFill
-                
-                // Present the scene
-                if let view = self.view as! SKView? {
-                    view.presentScene(sceneNode)
-                    
-                    view.ignoresSiblingOrder = true
-                    
-                    view.showsFPS = true
-                    view.showsNodeCount = true
-                }
-            }
-        }
+        presentInitialScene()
+    }
+
+    private func presentInitialScene() {
+        guard let view = self.view as? SKView else { return }
+        let scene = GameBoardScene(size: view.bounds.size)
+        scene.scaleMode = .aspectFill
+        view.presentScene(scene)
+        view.ignoresSiblingOrder = true
+        view.showsFPS = false
+        view.showsNodeCount = false
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/corgi jeopardy/Models/GameState.swift
+++ b/corgi jeopardy/Models/GameState.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+enum RoundType: Int, CaseIterable {
+    case jeopardy
+    case doubleJeopardy
+    case finalJeopardy
+
+    var baseClueValue: Int {
+        switch self {
+        case .jeopardy:
+            return 200
+        case .doubleJeopardy:
+            return 400
+        case .finalJeopardy:
+            return 0
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .jeopardy:
+            return "Jeopardy!"
+        case .doubleJeopardy:
+            return "Double Jeopardy!"
+        case .finalJeopardy:
+            return "Final Jeopardy!"
+        }
+    }
+}
+
+struct Clue {
+    let category: String
+    let prompt: String
+    let response: String
+    var value: Int
+    var isRevealed: Bool
+    var isDailyDouble: Bool
+    var isDailyDooDoo: Bool
+}
+
+struct CategoryBoard {
+    let title: String
+    var clues: [Clue]
+}
+
+final class GameState {
+    static let shared = GameState()
+
+    private(set) var playerScores: [String: Int] = ["Player1": 0, "AI1": 0]
+    private(set) var currentRound: RoundType = .jeopardy
+    private(set) var board: [CategoryBoard] = []
+
+    private let generalCategories: [String: [String]] = [
+        "History": [
+            "This ancient civilization built the pyramids.",
+            "He crossed the Delaware on Christmas night in 1776.",
+            "The war that ended with the Treaty of Versailles.",
+            "He wrote the 95 Theses in 1517.",
+            "This wall fell in 1989, reuniting a European city."
+        ],
+        "Science": [
+            "The powerhouse of the cell.",
+            "This planet is known as the Red Planet.",
+            "He developed the theory of relativity.",
+            "The chemical symbol for gold.",
+            "Number of bones in the adult human body (approximate)."
+        ],
+        "Literature": [
+            "He wrote 'Romeo and Juliet'.",
+            "This novel features the character Atticus Finch.",
+            "Author of '1984'.",
+            "The poet who wrote 'The Raven'.",
+            "Greek author of 'The Odyssey'."
+        ],
+        "Geography": [
+            "The longest river in the world.",
+            "This country is both an island and a continent.",
+            "The mountain range containing Mount Everest.",
+            "Capital city of Canada.",
+            "This desert covers much of northern Africa."
+        ]
+    ]
+
+    private let dogCategories: [String: [String]] = [
+        "Corgi Facts": [
+            "This is the country where corgis originated.",
+            "Corgis famously worked as this type of dog on farms.",
+            "The Queen of England favored this breed.",
+            "This corgi feature makes them look like loaves of bread.",
+            "Corgi tails are often described as this baked good." 
+        ],
+        "Paw-some Puns": [
+            "A corgi's favorite sci-fi series might be called this.",
+            "When a corgi relaxes on the beach, it's soaking up this.",
+            "A corgi detective solves cases using this sense.",
+            "Corgi math class is all about learning this kind of angle.",
+            "The corgi musician plays this instrument with a wag."
+        ],
+        "Doggy Delights": [
+            "A corgi's favorite frozen treat on a hot day.",
+            "This chew toy makes every corgi go wild.",
+            "The holiday where corgis wear costumes.",
+            "A corgi birthday cake is topped with this candle substitute.",
+            "This is the best topping for a corgi pizza night."
+        ]
+    ]
+
+    private init() {
+        generateBoard(for: currentRound)
+    }
+
+    func reset(players: [String] = ["Player1", "AI1"]) {
+        playerScores = players.reduce(into: [:]) { result, player in
+            result[player] = 0
+        }
+        currentRound = .jeopardy
+        generateBoard(for: currentRound)
+    }
+
+    func updateScore(player: String, delta: Int) {
+        guard playerScores[player] != nil else { return }
+        playerScores[player]! += delta
+    }
+
+    func markClueRevealed(categoryIndex: Int, clueIndex: Int) {
+        guard board.indices.contains(categoryIndex) else { return }
+        guard board[categoryIndex].clues.indices.contains(clueIndex) else { return }
+        board[categoryIndex].clues[clueIndex].isRevealed = true
+    }
+
+    var allCluesRevealed: Bool {
+        return board.flatMap { $0.clues }.allSatisfy { $0.isRevealed }
+    }
+
+    @discardableResult
+    func nextRound() -> RoundType {
+        switch currentRound {
+        case .jeopardy:
+            currentRound = .doubleJeopardy
+            generateBoard(for: currentRound)
+        case .doubleJeopardy:
+            currentRound = .finalJeopardy
+            board = []
+        case .finalJeopardy:
+            break
+        }
+        return currentRound
+    }
+
+    func generateBoard(for round: RoundType) {
+        guard round != .finalJeopardy else {
+            board = []
+            return
+        }
+
+        var availableGeneral = Array(generalCategories.keys)
+        var availableDog = Array(dogCategories.keys)
+
+        let dogCategoryCount = Int.random(in: 1...3)
+        let generalCategoryCount = 6 - dogCategoryCount
+
+        var selectedCategories: [CategoryBoard] = []
+
+        for _ in 0..<dogCategoryCount {
+            guard let key = availableDog.randomElement(), let prompts = dogCategories[key] else { continue }
+            availableDog.removeAll(where: { $0 == key })
+            let clues = createClues(for: key, prompts: prompts, round: round)
+            selectedCategories.append(CategoryBoard(title: key, clues: clues))
+        }
+
+        for _ in 0..<generalCategoryCount {
+            guard let key = availableGeneral.randomElement(), let prompts = generalCategories[key] else { continue }
+            availableGeneral.removeAll(where: { $0 == key })
+            let clues = createClues(for: key, prompts: prompts, round: round)
+            selectedCategories.append(CategoryBoard(title: key, clues: clues))
+        }
+
+        selectedCategories.shuffle()
+        assignSpecialClues(in: &selectedCategories, for: round)
+        board = selectedCategories
+    }
+
+    private func createClues(for category: String, prompts: [String], round: RoundType) -> [Clue] {
+        let baseValue = round.baseClueValue
+        return prompts.enumerated().map { index, prompt in
+            let value = baseValue * (index + 1)
+            return Clue(
+                category: category,
+                prompt: prompt,
+                response: "What is ...?",
+                value: value,
+                isRevealed: false,
+                isDailyDouble: false,
+                isDailyDooDoo: false
+            )
+        }
+    }
+
+    private func assignSpecialClues(in board: inout [CategoryBoard], for round: RoundType) {
+        guard !board.isEmpty else { return }
+
+        var allIndices: [(Int, Int)] = []
+        for (categoryIndex, category) in board.enumerated() {
+            for clueIndex in category.clues.indices {
+                allIndices.append((categoryIndex, clueIndex))
+            }
+        }
+
+        guard !allIndices.isEmpty else { return }
+
+        allIndices.shuffle()
+
+        let dailyDoubleCount = round == .doubleJeopardy ? 2 : 1
+        for i in 0..<min(dailyDoubleCount, allIndices.count) {
+            let (catIdx, clueIdx) = allIndices[i]
+            board[catIdx].clues[clueIdx].isDailyDouble = true
+        }
+
+        if let dooDooIndex = allIndices.dropFirst(dailyDoubleCount).first {
+            board[dooDooIndex.0].clues[dooDooIndex.1].isDailyDooDoo = true
+        }
+    }
+}

--- a/corgi jeopardy/Scenes/FinalJeopardyScene.swift
+++ b/corgi jeopardy/Scenes/FinalJeopardyScene.swift
@@ -1,0 +1,34 @@
+import SpriteKit
+
+final class FinalJeopardyScene: SKScene {
+    private let gameState = GameState.shared
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(red: 0.1, green: 0.12, blue: 0.2, alpha: 1.0)
+
+        let title = SKLabelNode(fontNamed: "AvenirNext-Bold")
+        title.text = "Final Jeopardy!"
+        title.fontSize = 36
+        title.fontColor = SKColor(red: 1.0, green: 0.85, blue: 0.35, alpha: 1.0)
+        title.position = CGPoint(x: 0, y: size.height / 2 - 120)
+        addChild(title)
+
+        let info = SKLabelNode(fontNamed: "AvenirNext-Regular")
+        info.text = "Final round logic coming soon. Scores carry over!"
+        info.fontSize = 22
+        info.fontColor = .white
+        info.position = CGPoint(x: 0, y: 0)
+        addChild(info)
+
+        var offset: CGFloat = -80
+        for (player, score) in gameState.playerScores.sorted(by: { $0.value > $1.value }) {
+            let label = SKLabelNode(fontNamed: "AvenirNext-Medium")
+            label.text = "\(player): $\(score)"
+            label.fontSize = 24
+            label.fontColor = .white
+            label.position = CGPoint(x: 0, y: offset)
+            addChild(label)
+            offset -= 40
+        }
+    }
+}

--- a/corgi jeopardy/Scenes/GameBoardScene.swift
+++ b/corgi jeopardy/Scenes/GameBoardScene.swift
@@ -1,0 +1,127 @@
+import SpriteKit
+
+final class GameBoardScene: SKScene {
+    private let gameState = GameState.shared
+    private var tileNodes: [[SKLabelNode]] = []
+    private var isPresentingTransition = false
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(red: 0.11, green: 0.13, blue: 0.25, alpha: 1.0)
+        removeAllChildren()
+        layoutCategoryLabels()
+        layoutClueTiles()
+        addCorgiHost()
+    }
+
+    private func layoutCategoryLabels() {
+        let topPadding: CGFloat = size.height * 0.15
+        let spacing: CGFloat = size.width / CGFloat(max(gameState.board.count, 1))
+
+        for (index, category) in gameState.board.enumerated() {
+            let label = SKLabelNode(fontNamed: "AvenirNext-Bold")
+            label.text = category.title.uppercased()
+            label.fontSize = 18
+            label.fontColor = .white
+            label.position = CGPoint(x: spacing * CGFloat(index) + spacing / 2 - size.width / 2,
+                                     y: size.height / 2 - topPadding)
+            label.numberOfLines = 0
+            label.preferredMaxLayoutWidth = spacing - 16
+            label.horizontalAlignmentMode = .center
+            label.verticalAlignmentMode = .center
+            addChild(label)
+        }
+    }
+
+    private func layoutClueTiles() {
+        tileNodes = []
+        guard !gameState.board.isEmpty else { return }
+
+        let columns = gameState.board.count
+        let rows = gameState.board.first?.clues.count ?? 0
+
+        let horizontalSpacing = size.width / CGFloat(columns)
+        let verticalSpacing = size.height * 0.6 / CGFloat(max(rows, 1))
+        let startingY = size.height / 2 - size.height * 0.25
+
+        for column in 0..<columns {
+            var columnNodes: [SKLabelNode] = []
+            for row in 0..<rows {
+                let clue = gameState.board[column].clues[row]
+                let node = SKLabelNode(fontNamed: "AvenirNext-Bold")
+                node.fontSize = 24
+                node.fontColor = clue.isRevealed ? SKColor.gray : SKColor(red: 1.0, green: 0.8, blue: 0.1, alpha: 1.0)
+                node.text = clue.isRevealed ? "" : "$\(clue.value)"
+                node.name = "clue_\(column)_\(row)"
+                node.position = CGPoint(x: horizontalSpacing * CGFloat(column) + horizontalSpacing / 2 - size.width / 2,
+                                        y: startingY - verticalSpacing * CGFloat(row))
+                node.verticalAlignmentMode = .center
+                node.horizontalAlignmentMode = .center
+
+                let backdrop = SKShapeNode(rectOf: CGSize(width: horizontalSpacing * 0.85, height: verticalSpacing * 0.75), cornerRadius: 12)
+                backdrop.fillColor = SKColor(red: 0.05, green: 0.08, blue: 0.2, alpha: 1.0)
+                backdrop.strokeColor = SKColor(red: 0.32, green: 0.46, blue: 0.86, alpha: 1.0)
+                backdrop.position = node.position
+                backdrop.name = node.name
+                addChild(backdrop)
+
+                addChild(node)
+                columnNodes.append(node)
+            }
+            tileNodes.append(columnNodes)
+        }
+    }
+
+    private func addCorgiHost() {
+        let hostNode = SKSpriteNode(color: SKColor(red: 0.95, green: 0.64, blue: 0.2, alpha: 1.0), size: CGSize(width: 120, height: 120))
+        hostNode.position = CGPoint(x: 0, y: -size.height / 2 + 120)
+        hostNode.name = "corgiHost"
+        addChild(hostNode)
+
+        let wag = SKAction.sequence([
+            SKAction.scaleX(to: 1.1, duration: 0.2),
+            SKAction.scaleX(to: 0.9, duration: 0.2)
+        ])
+        hostNode.run(SKAction.repeatForever(wag))
+    }
+
+    private func presentTransitionScene() {
+        guard !isPresentingTransition else { return }
+        isPresentingTransition = true
+
+        let transitionScene = TransitionScene(size: size)
+        transitionScene.scaleMode = scaleMode
+        let reveal = SKTransition.crossFade(withDuration: 1.0)
+        view?.presentScene(transitionScene, transition: reveal)
+    }
+
+    private func handleClueSelection(categoryIndex: Int, clueIndex: Int) {
+        guard gameState.board.indices.contains(categoryIndex) else { return }
+        guard gameState.board[categoryIndex].clues.indices.contains(clueIndex) else { return }
+        guard !gameState.board[categoryIndex].clues[clueIndex].isRevealed else { return }
+
+        gameState.markClueRevealed(categoryIndex: categoryIndex, clueIndex: clueIndex)
+        let node = tileNodes[categoryIndex][clueIndex]
+        node.text = ""
+        node.fontColor = .gray
+
+        if gameState.allCluesRevealed {
+            presentTransitionScene()
+        }
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        let location = touch.location(in: self)
+        let nodesAtPoint = nodes(at: location)
+
+        for node in nodesAtPoint {
+            guard let name = node.name, name.hasPrefix("clue_") else { continue }
+            let components = name.split(separator: "_")
+            guard components.count == 3,
+                  let column = Int(components[1]),
+                  let row = Int(components[2]) else { continue }
+            handleClueSelection(categoryIndex: column, clueIndex: row)
+            break
+        }
+    }
+}

--- a/corgi jeopardy/Scenes/TransitionScene.swift
+++ b/corgi jeopardy/Scenes/TransitionScene.swift
@@ -1,0 +1,79 @@
+import SpriteKit
+
+final class TransitionScene: SKScene {
+    private let gameState = GameState.shared
+    private let displayDuration: TimeInterval = 3.0
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(red: 0.07, green: 0.09, blue: 0.18, alpha: 1.0)
+        addTitleLabel()
+        addScoreboard()
+        addCelebrationCorgi()
+        scheduleAdvance()
+    }
+
+    private func addTitleLabel() {
+        let title = SKLabelNode(fontNamed: "AvenirNext-Bold")
+        title.text = "Next up: \(gameState.currentRound.displayName)"
+        title.fontSize = 32
+        title.fontColor = SKColor(red: 1.0, green: 0.89, blue: 0.4, alpha: 1.0)
+        title.position = CGPoint(x: 0, y: size.height / 2 - 120)
+        addChild(title)
+    }
+
+    private func addScoreboard() {
+        let sortedScores = gameState.playerScores.sorted { $0.value > $1.value }
+        for (index, entry) in sortedScores.enumerated() {
+            let label = SKLabelNode(fontNamed: "AvenirNext-Medium")
+            label.text = "\(entry.key): $\(entry.value)"
+            label.fontSize = 24
+            label.fontColor = .white
+            label.position = CGPoint(x: 0, y: size.height / 2 - 200 - CGFloat(index) * 40)
+            addChild(label)
+        }
+    }
+
+    private func addCelebrationCorgi() {
+        let corgi = SKSpriteNode(color: SKColor(red: 0.95, green: 0.74, blue: 0.33, alpha: 1.0), size: CGSize(width: 150, height: 150))
+        corgi.position = CGPoint(x: 0, y: -40)
+        addChild(corgi)
+
+        let wiggle = SKAction.sequence([
+            SKAction.rotate(byAngle: .pi / 16, duration: 0.2),
+            SKAction.rotate(byAngle: -.pi / 8, duration: 0.2),
+            SKAction.rotate(byAngle: .pi / 16, duration: 0.2)
+        ])
+        let hop = SKAction.sequence([
+            SKAction.moveBy(x: 0, y: 20, duration: 0.2),
+            SKAction.moveBy(x: 0, y: -20, duration: 0.2)
+        ])
+        let dance = SKAction.group([SKAction.repeatForever(wiggle), SKAction.repeatForever(hop)])
+        corgi.run(dance)
+    }
+
+    private func scheduleAdvance() {
+        run(SKAction.sequence([
+            SKAction.wait(forDuration: displayDuration),
+            SKAction.run { [weak self] in
+                self?.advanceToNextRound()
+            }
+        ]))
+    }
+
+    private func advanceToNextRound() {
+        let next = gameState.nextRound()
+
+        switch next {
+        case .jeopardy, .doubleJeopardy:
+            let nextBoard = GameBoardScene(size: size)
+            nextBoard.scaleMode = scaleMode
+            let transition = SKTransition.flipHorizontal(withDuration: 1.0)
+            view?.presentScene(nextBoard, transition: transition)
+        case .finalJeopardy:
+            let finalScene = FinalJeopardyScene(size: size)
+            finalScene.scaleMode = scaleMode
+            let transition = SKTransition.doorsOpenHorizontal(withDuration: 1.0)
+            view?.presentScene(finalScene, transition: transition)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared GameState that manages players, board generation, and round advancement
- build a GameBoardScene grid that marks clues as revealed and triggers round transitions
- show a TransitionScene with scores and corgi celebration before moving to Double or Final Jeopardy, including a placeholder FinalJeopardyScene
- update the view controller to launch the new GameBoardScene

## Testing
- Not run (SpriteKit scenes require iOS simulator)


------
https://chatgpt.com/codex/tasks/task_e_68e01afa3c20832c957202b50ef41d8a