### PR TITLE
Implement Daily Double wager flow

### DIFF
--- a/corgi jeopardy/Clue.swift
+++ b/corgi jeopardy/Clue.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Represents a single trivia clue on the board.
+struct Clue {
+    let value: Int
+    let question: String
+    let answer: String
+    let isDailyDouble: Bool
+}

--- a/corgi jeopardy/ClueScene.swift
+++ b/corgi jeopardy/ClueScene.swift
@@ -1,0 +1,130 @@
+import SpriteKit
+import UIKit
+
+/// Scene responsible for presenting the clue and handling user answers.
+class ClueScene: SKScene {
+    private let clue: Clue
+    private let isWager: Bool
+    private let questionLabel = SKLabelNode(fontNamed: "AvenirNext-Bold")
+    private let resultLabel = SKLabelNode(fontNamed: "AvenirNext-Bold")
+    private var answerField: UITextField?
+    private var submitButton: SKLabelNode?
+
+    init(size: CGSize, clue: Clue, isWager: Bool = false) {
+        self.clue = clue
+        self.isWager = isWager
+        super.init(size: size)
+        self.scaleMode = .aspectFill
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(red: 0.05, green: 0.07, blue: 0.16, alpha: 1.0)
+
+        questionLabel.text = clue.question
+        questionLabel.fontSize = 30
+        questionLabel.numberOfLines = 0
+        questionLabel.preferredMaxLayoutWidth = size.width * 0.8
+        questionLabel.position = CGPoint(x: size.width / 2, y: size.height * 0.65)
+        addChild(questionLabel)
+
+        resultLabel.fontSize = 26
+        resultLabel.position = CGPoint(x: size.width / 2, y: size.height * 0.45)
+        resultLabel.alpha = 0
+        addChild(resultLabel)
+
+        let submit = SKLabelNode(fontNamed: "AvenirNext-Bold")
+        submit.name = "submitAnswer"
+        submit.text = "Submit Answer"
+        submit.fontSize = 24
+        submit.position = CGPoint(x: size.width / 2, y: size.height * 0.35)
+        addChild(submit)
+        submitButton = submit
+
+        configureTextField(in: view)
+
+        // Play the corgi sound effect when the clue appears.
+        run(SKAction.playSoundFileNamed("corgi_bark.wav", waitForCompletion: false))
+    }
+
+    private func configureTextField(in view: SKView) {
+        let width = min(view.bounds.width * 0.7, 320)
+        let textFieldFrame = CGRect(x: (view.bounds.width - width) / 2,
+                                    y: view.bounds.height * 0.55,
+                                    width: width,
+                                    height: 44)
+        let textField = UITextField(frame: textFieldFrame)
+        textField.placeholder = "Respond in the form of a question"
+        textField.borderStyle = .roundedRect
+        textField.returnKeyType = .done
+        textField.autocapitalizationType = .sentences
+        textField.delegate = self
+        view.addSubview(textField)
+        textField.becomeFirstResponder()
+        answerField = textField
+    }
+
+    private func evaluateAnswer() {
+        guard let text = answerField?.text else { return }
+
+        let normalizedResponse = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedAnswer = clue.answer.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let isQuestionFormat = normalizedResponse.hasPrefix("what is") || normalizedResponse.hasPrefix("who is") || normalizedResponse.hasPrefix("where is")
+        let containsAnswer = normalizedResponse.contains(normalizedAnswer)
+        let isCorrect = isQuestionFormat && containsAnswer
+
+        let wagerValue = isWager ? GameState.shared.currentWager : clue.value
+        let delta = isCorrect ? wagerValue : -wagerValue
+        GameState.shared.updateCurrentPlayerScore(by: delta)
+
+        let resultText = isCorrect ? "Correct! +$\(wagerValue)" : "Incorrect! -$\(wagerValue)"
+        resultLabel.text = resultText
+        resultLabel.fontColor = isCorrect ? .green : .red
+        resultLabel.alpha = 1
+
+        answerField?.resignFirstResponder()
+        answerField?.isEnabled = false
+        submitButton?.alpha = 0.4
+        submitButton?.isUserInteractionEnabled = false
+
+        run(SKAction.sequence([
+            SKAction.wait(forDuration: 2.0),
+            SKAction.run { [weak self] in
+                self?.returnToBoard()
+            }
+        ]))
+    }
+
+    private func returnToBoard() {
+        guard let view = view else { return }
+        let boardScene = GameScene(size: view.bounds.size)
+        view.presentScene(boardScene, transition: SKTransition.fade(withDuration: 0.5))
+    }
+
+    override func willMove(from view: SKView) {
+        super.willMove(from: view)
+        answerField?.removeFromSuperview()
+        answerField = nil
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        let location = touch.location(in: self)
+        let nodes = nodes(at: location)
+
+        if nodes.contains(where: { $0.name == "submitAnswer" }) {
+            evaluateAnswer()
+        }
+    }
+}
+
+extension ClueScene: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        evaluateAnswer()
+        return true
+    }
+}

--- a/corgi jeopardy/GameState.swift
+++ b/corgi jeopardy/GameState.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// A simple global game state model used to coordinate scores and wagers across scenes.
+final class GameState {
+    static let shared = GameState()
+
+    /// Mapping of player identifiers to their scores.
+    var playerScores: [String: Int]
+
+    /// Identifier for the player whose turn it currently is.
+    var currentTurn: String
+
+    /// Stores the most recent wager placed for Daily Double style clues.
+    var currentWager: Int
+
+    private init() {
+        // Provide a minimal default configuration so the app can run
+        // even before real player data has been configured.
+        self.playerScores = ["Player1": 0]
+        self.currentTurn = "Player1"
+        self.currentWager = 0
+    }
+
+    /// Convenience accessor for the active player's score.
+    var currentPlayerScore: Int {
+        return playerScores[currentTurn] ?? 0
+    }
+
+    /// Updates the score for a particular player by the provided amount.
+    func updateScore(for player: String, by delta: Int) {
+        let current = playerScores[player] ?? 0
+        playerScores[player] = current + delta
+    }
+
+    /// Updates the score for the active player.
+    func updateCurrentPlayerScore(by delta: Int) {
+        updateScore(for: currentTurn, by: delta)
+    }
+}

--- a/corgi jeopardy/WagerScene.swift
+++ b/corgi jeopardy/WagerScene.swift
@@ -1,0 +1,120 @@
+import SpriteKit
+import UIKit
+
+/// Scene displayed when a player hits a Daily Double and must enter a wager.
+class WagerScene: SKScene {
+    private let clue: Clue
+    private let promptLabel = SKLabelNode(fontNamed: "AvenirNext-Bold")
+    private let feedbackLabel = SKLabelNode(fontNamed: "AvenirNext-Regular")
+    private var wagerField: UITextField?
+    private let maxWager: Int
+
+    init(size: CGSize, clue: Clue) {
+        self.clue = clue
+        self.maxWager = max(0, GameState.shared.currentPlayerScore)
+        super.init(size: size)
+        self.scaleMode = .aspectFill
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor.black
+
+        promptLabel.text = "Daily Double! Wager up to your score: $\(maxWager)"
+        promptLabel.fontSize = 28
+        promptLabel.numberOfLines = 0
+        promptLabel.preferredMaxLayoutWidth = size.width * 0.8
+        promptLabel.position = CGPoint(x: size.width / 2, y: size.height * 0.65)
+        addChild(promptLabel)
+
+        feedbackLabel.fontSize = 20
+        feedbackLabel.fontColor = .red
+        feedbackLabel.position = CGPoint(x: size.width / 2, y: size.height * 0.55)
+        feedbackLabel.alpha = 0
+        addChild(feedbackLabel)
+
+        let submitButton = SKLabelNode(fontNamed: "AvenirNext-Bold")
+        submitButton.name = "submitButton"
+        submitButton.text = "Submit Wager"
+        submitButton.fontSize = 24
+        submitButton.position = CGPoint(x: size.width / 2, y: size.height * 0.4)
+        addChild(submitButton)
+
+        let cancelButton = SKLabelNode(fontNamed: "AvenirNext-Regular")
+        cancelButton.name = "cancelButton"
+        cancelButton.text = "Cancel"
+        cancelButton.fontSize = 20
+        cancelButton.position = CGPoint(x: size.width / 2, y: size.height * 0.3)
+        addChild(cancelButton)
+
+        configureTextField(in: view)
+    }
+
+    private func configureTextField(in view: SKView) {
+        let width = min(view.bounds.width * 0.6, 280)
+        let textFieldFrame = CGRect(x: (view.bounds.width - width) / 2,
+                                    y: view.bounds.height * 0.45,
+                                    width: width,
+                                    height: 44)
+        let textField = UITextField(frame: textFieldFrame)
+        textField.placeholder = "Enter wager"
+        textField.borderStyle = .roundedRect
+        textField.keyboardType = .numberPad
+        textField.textAlignment = .center
+        textField.becomeFirstResponder()
+        view.addSubview(textField)
+        wagerField = textField
+    }
+
+    override func willMove(from view: SKView) {
+        super.willMove(from: view)
+        wagerField?.removeFromSuperview()
+        wagerField = nil
+    }
+
+    private func showValidation(message: String) {
+        feedbackLabel.text = message
+        feedbackLabel.alpha = 1
+        feedbackLabel.run(SKAction.sequence([
+            SKAction.wait(forDuration: 2.0),
+            SKAction.fadeOut(withDuration: 0.3)
+        ]))
+    }
+
+    private func validateAndProceed() {
+        guard let text = wagerField?.text, let wager = Int(text) else {
+            showValidation(message: "Please enter a valid number.")
+            return
+        }
+
+        guard wager >= 0 && wager <= maxWager else {
+            showValidation(message: "Wager must be between 0 and $\(maxWager).")
+            return
+        }
+
+        GameState.shared.currentWager = wager
+        presentClueScene()
+    }
+
+    private func presentClueScene() {
+        guard let view = view else { return }
+        let clueScene = ClueScene(size: view.bounds.size, clue: clue, isWager: true)
+        view.presentScene(clueScene, transition: SKTransition.crossFade(withDuration: 0.5))
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        let location = touch.location(in: self)
+        let nodes = nodes(at: location)
+
+        if nodes.contains(where: { $0.name == "submitButton" }) {
+            validateAndProceed()
+        } else if nodes.contains(where: { $0.name == "cancelButton" }) {
+            wagerField?.text = ""
+            presentClueScene()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight GameState model and Clue struct to share score information between scenes
- create a dedicated WagerScene that validates wagers before presenting the clue
- update the ClueScene flow to honor wagers, adjust scores, and play the corgi reveal sound

## Testing
- not run (xcodebuild is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e01b1324ec832cb07eb17c2d96490a