### PR TITLE
Add GameState model with wagering logic and unit tests

### DIFF
--- a/corgi jeopardy/GameState.swift
+++ b/corgi jeopardy/GameState.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+struct GameState {
+    struct Category: Equatable {
+        let name: String
+        let clues: [Clue]
+        let isDogCategory: Bool
+    }
+
+    struct Clue: Equatable {
+        let prompt: String
+        let response: String
+        let value: Int
+    }
+
+    private(set) var score: Int
+    private(set) var board: [Category]
+
+    private static let dogCategoryPool: [Category] = [
+        Category(name: "Corgi Lore", clues: GameState.makeDefaultClues(prefix: "Corgi"), isDogCategory: true),
+        Category(name: "Working Dogs", clues: GameState.makeDefaultClues(prefix: "Working"), isDogCategory: true),
+        Category(name: "Famous Dogs", clues: GameState.makeDefaultClues(prefix: "Famous"), isDogCategory: true),
+        Category(name: "Dog Training", clues: GameState.makeDefaultClues(prefix: "Training"), isDogCategory: true)
+    ]
+
+    private static let generalCategoryPool: [Category] = [
+        Category(name: "Dog Adjacent Trivia", clues: GameState.makeDefaultClues(prefix: "Adjacent"), isDogCategory: false),
+        Category(name: "Pet Care", clues: GameState.makeDefaultClues(prefix: "Care"), isDogCategory: false),
+        Category(name: "Corgi History", clues: GameState.makeDefaultClues(prefix: "History"), isDogCategory: false),
+        Category(name: "Agility", clues: GameState.makeDefaultClues(prefix: "Agility"), isDogCategory: false),
+        Category(name: "Parks", clues: GameState.makeDefaultClues(prefix: "Parks"), isDogCategory: false),
+        Category(name: "Treats", clues: GameState.makeDefaultClues(prefix: "Treats"), isDogCategory: false)
+    ]
+
+    init(score: Int = 0, board: [Category] = []) {
+        self.score = score
+        self.board = board
+    }
+
+    mutating func updateScore(for value: Int, isCorrect: Bool, isWager: Bool = false) {
+        let sanitizedValue = max(0, value)
+        if isWager {
+            let allowedWager = max(0, min(sanitizedValue, max(score, 0)))
+            score += isCorrect ? allowedWager : -allowedWager
+        } else {
+            score += isCorrect ? sanitizedValue : -sanitizedValue
+        }
+    }
+
+    mutating func generateBoard(categoryCount: Int = 6, using generator: inout some RandomNumberGenerator) {
+        let dogCategoryLimit = min(3, GameState.dogCategoryPool.count)
+        let dogCountUpperBound = max(1, min(categoryCount, dogCategoryLimit))
+        let dogCount = Int.random(in: 1...dogCountUpperBound, using: &generator)
+        let generalCount = max(0, categoryCount - dogCount)
+
+        let dogCategories = Array(GameState.dogCategoryPool.shuffled(using: &generator).prefix(dogCount))
+        let generalCategories = Array(GameState.generalCategoryPool.shuffled(using: &generator).prefix(generalCount))
+
+        board = dogCategories + generalCategories
+    }
+
+    mutating func generateBoard(categoryCount: Int = 6) {
+        var generator = SystemRandomNumberGenerator()
+        generateBoard(categoryCount: categoryCount, using: &generator)
+    }
+
+    func validateAnswer(_ userAnswer: String, correctAnswer: String) -> Bool {
+        let normalizedUser = GameState.normalized(answer: userAnswer)
+        let normalizedCorrect = GameState.normalized(answer: correctAnswer)
+        guard !normalizedUser.isEmpty, !normalizedCorrect.isEmpty else { return false }
+        return normalizedUser == normalizedCorrect
+    }
+
+    private static func normalized(answer: String) -> String {
+        let trimmed = answer.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else { return "" }
+
+        let response = trimmed
+            .replacingOccurrences(of: "what is", with: "", options: [.anchored, .caseInsensitive])
+            .replacingOccurrences(of: "who is", with: "", options: [.anchored, .caseInsensitive])
+            .replacingOccurrences(of: "where is", with: "", options: [.anchored, .caseInsensitive])
+            .replacingOccurrences(of: "what are", with: "", options: [.anchored, .caseInsensitive])
+            .replacingOccurrences(of: "who are", with: "", options: [.anchored, .caseInsensitive])
+            .replacingOccurrences(of: "where are", with: "", options: [.anchored, .caseInsensitive])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let allowedCharacters = CharacterSet.alphanumerics
+        let normalized = response.unicodeScalars.filter { allowedCharacters.contains($0) }.map { Character($0) }
+        return String(normalized)
+    }
+
+    private static func makeDefaultClues(prefix: String) -> [Clue] {
+        return stride(from: 200, through: 1000, by: 200).map { value in
+            Clue(prompt: "\(prefix) clue for \(value)", response: "\(prefix) answer \(value)", value: value)
+        }
+    }
+}

--- a/corgi jeopardyTests/GameStateTests.swift
+++ b/corgi jeopardyTests/GameStateTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import corgi_jeopardy
+
+final class GameStateTests: XCTestCase {
+
+    func testUpdateScore() {
+        var gameState = GameState()
+        gameState.updateScore(for: 200, isCorrect: true)
+        XCTAssertEqual(gameState.score, 200, "Correct answers should add the clue value to the score.")
+
+        gameState.updateScore(for: 400, isCorrect: false)
+        XCTAssertEqual(gameState.score, -200, "Incorrect answers should subtract the clue value, allowing negative scores.")
+
+        gameState = GameState(score: 1000)
+        gameState.updateScore(for: 2000, isCorrect: true, isWager: true)
+        XCTAssertEqual(gameState.score, 2000, "Wagers should be clamped to the available score when answering correctly.")
+
+        gameState.updateScore(for: 2000, isCorrect: false, isWager: true)
+        XCTAssertEqual(gameState.score, 1000, "Wagers larger than the score should be clamped when answered incorrectly as well.")
+
+        gameState.updateScore(for: -500, isCorrect: true, isWager: true)
+        XCTAssertEqual(gameState.score, 1000, "Negative wagers should be treated as zero to avoid inflating the score.")
+    }
+
+    func testGenerateBoardEnsuresDogCategories() {
+        var generator = PredictableRandomNumberGenerator(seed: 42)
+        var gameState = GameState()
+        gameState.generateBoard(categoryCount: 6, using: &generator)
+
+        XCTAssertEqual(gameState.board.count, 6, "A standard Jeopardy round should contain six categories.")
+
+        let dogCategories = gameState.board.filter { $0.isDogCategory }
+        XCTAssertGreaterThanOrEqual(dogCategories.count, 1, "The generated board should always include at least one dog-themed category.")
+        XCTAssertLessThanOrEqual(dogCategories.count, 3, "The generated board should include no more than three dog-themed categories to preserve variety.")
+
+        let uniqueCategoryNames = Set(gameState.board.map { $0.name })
+        XCTAssertEqual(uniqueCategoryNames.count, gameState.board.count, "Board generation should not duplicate category names in a single round.")
+    }
+
+    func testAnswerValidation() {
+        let gameState = GameState()
+
+        XCTAssertTrue(gameState.validateAnswer("What is Corgi?", correctAnswer: "corgi"))
+        XCTAssertTrue(gameState.validateAnswer("WHO ARE THE CORGIS", correctAnswer: "Corgis"))
+        XCTAssertTrue(gameState.validateAnswer("Corgi lore!", correctAnswer: "corgi lore"))
+
+        XCTAssertFalse(gameState.validateAnswer("", correctAnswer: "corgi"), "Empty answers should be treated as invalid.")
+        XCTAssertFalse(gameState.validateAnswer("Cat", correctAnswer: "corgi"), "Mismatched answers should return false.")
+    }
+}
+
+private struct PredictableRandomNumberGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state = state &* 6364136223846793005 &+ 1442695040888963407
+        return state
+    }
+}

--- a/corgi jeopardyTests/corgi_jeopardyTests.swift
+++ b/corgi jeopardyTests/corgi_jeopardyTests.swift
@@ -1,17 +1,9 @@
-//
-//  corgi_jeopardyTests.swift
-//  corgi jeopardyTests
-//
-//  Created by John Clem on 10/2/25.
-//
-
-import Testing
-@testable import corgi_jeopardy
-
-struct corgi_jeopardyTests {
-
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    }
-
-}
+// SpriteKit debugging tips:
+// - Use the `showsPhysics` and `showsFields` properties on `SKView` to visualize nodes during touch handling.
+// - Enable `showsFPS` and `showsNodeCount` to verify that scene transitions finish and resources are deallocated.
+// - Log `touchesBegan`, `touchesMoved`, and `touchesEnded` with node names to confirm gesture routing when debugging custom buttons.
+// - During transitions, confirm `presentScene(_:transition:)` is called on the main thread and set `view?.ignoresSiblingOrder = false` when
+//   testing zPosition ordering issues.
+// - Pause the scene (`isPaused = true`) while stepping through touch responders in Xcode to avoid missing events.
+// - When touches seem unresponsive, ensure `isUserInteractionEnabled` is true on the relevant nodes and that gesture recognizers are not
+//   intercepting touches before SpriteKit.


### PR DESCRIPTION
## Summary
- add a GameState model that encapsulates score updates, board generation, and answer validation logic
- create deterministic XCTest coverage for GameState behaviors, including wagering clamps and answer normalization
- record SpriteKit touch and transition debugging tips for quick reference in the test target

## Testing
- not run (xcodebuild is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e01b32d370832c9ded43a6d9bb86b9